### PR TITLE
[FIX] import: from odoo => from openerp

### DIFF
--- a/hr_employee_time_clock/models/res_users.py
+++ b/hr_employee_time_clock/models/res_users.py
@@ -21,7 +21,7 @@
 ##############################################################################
 
 
-from odoo import fields, models, SUPERUSER_ID, api
+from openerp import fields, models, SUPERUSER_ID, api
 import logging
 
 _logger = logging.getLogger(__name__)

--- a/hr_employee_time_clock/models/res_users.py
+++ b/hr_employee_time_clock/models/res_users.py
@@ -30,7 +30,6 @@ _logger = logging.getLogger(__name__)
 class ResUsers(models.Model):
     _inherit = 'res.users'
 
-    @classmethod
     def authenticate(cls, db, login, password, user_agent_env):
         uid = cls._login(db, login, password)
         if uid == SUPERUSER_ID:


### PR DESCRIPTION
Latest commit 5c21fad doesn't contain any tests, so I cannot make sure your latest commit still works with my fixes applied. The latest commit 5c21fad breaks website auth with the following stack trace:
```
2019-03-14 08:36:16,448 26956 INFO <DB> werkzeug: <IP> - - [14/Mar/2019 08:36:16] "GET /web/login?redirect=<URL> HTTP/1.0" 200 -
2019-03-14 08:36:31,361 26955 INFO <DB> openerp.addons.base.ir.ir_http: Generating routing map
2019-03-14 08:36:31,438 26955 ERROR <DB> openerp.http: unbound method _login() must be called with res.users instance as first argument (got unicode instance instead)
Traceback (most recent call last):
  File "/home/<USER>/odoo/openerp/http.py", line 115, in dispatch_rpc
    result = dispatch(method, params)
  File "/home/<USER>/odoo/openerp/service/common.py", line 26, in dispatch
    return fn(*params)
  File "/home/<USER>/odoo/openerp/service/common.py", line 38, in exp_authenticate
    return res_users.authenticate(db, login, password, user_agent_env)
  File "/home/<USER>/addons/hr_employee_time_clock/models/res_users.py", line 35, in authenticate
    uid = cls._login(db, login, password)
TypeError: unbound method _login() must be called with res.users instance as first argument (got unicode instance instead)
2019-03-14 08:36:31,444 26955 ERROR <DB> openerp.addons.website.models.ir_http: 500 Internal Server Error:

Traceback (most recent call last):
  File "/home/<USER>/odoo/addons/website/models/ir_http.py", line 199, in _handle_exception
    response = super(ir_http, self)._handle_exception(exception)
  File "/home/<USER>/odoo/openerp/addons/base/ir/ir_http.py", line 145, in _handle_exception
    return request._handle_exception(exception)
  File "/home/<USER>/odoo/openerp/http.py", line 668, in _handle_exception
    return super(HttpRequest, self)._handle_exception(exception)
  File "/home/<USER>/odoo/openerp/addons/base/ir/ir_http.py", line 171, in _dispatch
    result = request.dispatch()
  File "/home/<USER>/odoo/openerp/http.py", line 686, in dispatch
    r = self._call_function(**self.params)
  File "/home/<USER>/odoo/openerp/http.py", line 312, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/<USER>/odoo/openerp/service/model.py", line 118, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/<USER>/odoo/openerp/http.py", line 309, in checked_call
    return self.endpoint(*a, **kw)
  File "/home/<USER>/odoo/openerp/http.py", line 805, in __call__
    return self.method(*args, **kw)
  File "/home/<USER>/odoo/openerp/http.py", line 405, in response_wrap
    response = f(*args, **kw)
  File "/home/<USER>/odoo/addons/website/controllers/main.py", line 52, in web_login
    return super(Website, self).web_login(*args, **kw)
  File "/home/<USER>/odoo/openerp/http.py", line 405, in response_wrap
    response = f(*args, **kw)
  File "/home/<USER>/odoo/addons/auth_signup/controllers/main.py", line 38, in web_login
    response = super(AuthSignupHome, self).web_login(*args, **kw)
  File "/home/<USER>/odoo/openerp/http.py", line 405, in response_wrap
    response = f(*args, **kw)
  File "/home/<USER>/odoo/addons/web/controllers/main.py", line 509, in web_login
    uid = request.session.authenticate(request.session.db, request.params['login'], request.params['password'])
  File "/home/<USER>/odoo/openerp/http.py", line 958, in authenticate
    uid = dispatch_rpc('common', 'authenticate', [db, login, password, env])
  File "/home/<USER>/odoo/openerp/http.py", line 115, in dispatch_rpc
    result = dispatch(method, params)
  File "/home/<USER>/odoo/openerp/service/common.py", line 26, in dispatch
    return fn(*params)
  File "/home/<USER>/odoo/openerp/service/common.py", line 38, in exp_authenticate
    return res_users.authenticate(db, login, password, user_agent_env)
  File "/home/<USER>/addons/hr_employee_time_clock/models/res_users.py", line 35, in authenticate
    uid = cls._login(db, login, password)
TypeError: unbound method _login() must be called with res.users instance as first argument (got unicode instance instead)
2019-03-14 08:36:31,478 26955 INFO <DB> werkzeug: <IP> - - [14/Mar/2019 08:36:31] "POST /web/login HTTP/1.0" 500 -
```