### PR TITLE
Small bugfix for compute-function

### DIFF
--- a/hr_employee_time_clock/models/hr_timesheet_dh.py
+++ b/hr_employee_time_clock/models/hr_timesheet_dh.py
@@ -167,8 +167,8 @@ class HrTimesheetDh(models.Model):
                     output.append('<th colspan="2">' + prev_ts + ' </th>')
                     output.append('<td colspan="3">' + t + '</td>')
                     output.append('</tr>')
-            keys = ('Date', 'Duty Hours', 'Worked Hours',
-                    'Difference', 'Running')
+            keys = (_('Date'), _('Duty Hours'), _('Worked Hours'),
+                    _('Difference'), _('Running'))
             a = ('previous_month_diff', 'hours', 'total')
             for k in a:
                 v = data.get(k)

--- a/hr_employee_time_clock/models/hr_timesheet_sheet.py
+++ b/hr_employee_time_clock/models/hr_timesheet_sheet.py
@@ -28,6 +28,33 @@ from odoo.exceptions import ValidationError
 class HrTimesheetSheet(models.Model):
     _inherit = "hr_timesheet_sheet.sheet"
 
+    def _total(self):
+        """
+            Compute the attendances, analytic lines timesheets and differences between them
+            for all the days of a timesheet and the current day.
+        :return:
+        """
+        cr = self.env.cr
+        res = dict.fromkeys(self.ids, {
+            'total_attendance': 0.0,
+            'total_timesheet': 0.0,
+            'total_difference': 0.0,
+        })
+
+        cr.execute("""
+                    SELECT sheet_id as id,
+                           sum(total_attendance) as total_attendance,
+                           sum(total_timesheet) as total_timesheet,
+                           sum(total_difference) as  total_difference
+                    FROM hr_timesheet_sheet_sheet_day
+                    WHERE sheet_id IN %s
+                    GROUP BY sheet_id
+                """, (tuple(self.ids),))
+
+        res.update(dict((x.pop('id'), x) for x in cr.dictfetchall()))
+
+        return res
+    
     def _total(self, cr, uid, ids, name, args, context=None):
         """ Compute the attendances, analytic lines timesheets
         and differences between them


### PR DESCRIPTION
The original function requires parameters which are not supported by compute of the model. This causes errors when trying to open time sheets in Odoo.